### PR TITLE
fix(readme.md) lua import path is wrong

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ npm run compile
 ## Setup
 
 ```lua
-require("nvim-dap-vscode-js").setup({
+require("dap-vscode-js").setup({
   -- node_path = "node", -- Path of node executable. Defaults to $NODE_PATH, and then "node"
   -- debugger_path = "(runtimedir)/site/pack/packer/opt/vscode-js-debug", -- Path to vscode-js-debug installation. 
   adapters = { 'pwa-node', 'pwa-chrome', 'pwa-msedge', 'node-terminal', 'pwa-extensionHost' }, -- which adapters to register in nvim-dap


### PR DESCRIPTION
The lua import path was the plugin name instead of the lua subdirectory name