### PR TITLE
feat: add debugger_cmd config

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ npm run compile
 ```lua
 require("dap-vscode-js").setup({
   -- node_path = "node", -- Path of node executable. Defaults to $NODE_PATH, and then "node"
-  -- debugger_path = "(runtimedir)/site/pack/packer/opt/vscode-js-debug", -- Path to vscode-js-debug installation. 
+  -- debugger_path = "(runtimedir)/site/pack/packer/opt/vscode-js-debug", -- Path to vscode-js-debug installation.
+  -- debugger_cmd = { "js-debug-adapter" }, -- Command to use to launch the debug server. Takes precedence over `node_path` and `debugger_path`.
   adapters = { 'pwa-node', 'pwa-chrome', 'pwa-msedge', 'node-terminal', 'pwa-extensionHost' }, -- which adapters to register in nvim-dap
 })
 

--- a/lua/dap-vscode-js/config.lua
+++ b/lua/dap-vscode-js/config.lua
@@ -3,6 +3,7 @@ local utils = require("dap-vscode-js.utils")
 local defaults = {
 	node_path = os.getenv("NODE_PATH") or "node",
 	debugger_path = utils.join_paths(utils.get_runtime_dir(), "site/pack/packer/opt/vscode-js-debug"),
+	debugger_cmd = nil,
 }
 
 local config = vim.deepcopy(defaults)

--- a/lua/dap-vscode-js/init.lua
+++ b/lua/dap-vscode-js/init.lua
@@ -3,6 +3,7 @@
 ---@class Settings @Plugin configuration options
 ---@field node_path string: Path of node executable. Defaults to $NODE_PATH, and then "node"
 ---@field debugger_path string: Path to vscode-js-debug. Defaults to (runtimedir)/site/pack/packer/opt/vscode-js-debug
+---@field debugger_cmd string[]?: The command to use to launch the debug server. This option takes precedence over both `node_path` and `debugger_path`.
 ---@field adapters string[]: List of adapters to configure. Options are 'pwa-node', 'pwa-chrome', 'pwa-msedge', 'node-terminal', 'pwa-extensionHost'. Defaults to all. See https://github.com/microsoft/vscode-js-debug/blob/main/OPTIONS.md for configuration options.
 
 local config = require("dap-vscode-js.config")

--- a/lua/dap-vscode-js/utils.lua
+++ b/lua/dap-vscode-js/utils.lua
@@ -49,6 +49,19 @@ local function debugger_entrypoint(debugger_path)
 	return M.join_paths(debugger_path, "out/src/vsDebugServer.js")
 end
 
+---@param config Settings
+local function get_spawn_cmd(config)
+	if config.debugger_cmd then
+		return assert(config.debugger_cmd[1], "debugger_cmd is empty"), { unpack(config.debugger_cmd, 2) }
+	end
+	local entrypoint = debugger_entrypoint(config.debugger_path)
+
+	if not file_exists(entrypoint) then
+		error("Debugger entrypoint file '" .. entrypoint .. "' does not exist. Did it build properly?")
+	end
+	return config.node_path, { entrypoint }
+end
+
 function M.start_debugger(config, on_launch, on_exit, on_error, on_stderror)
 	on_launch = schedule_wrap_safe(on_launch)
 	on_exit = schedule_wrap_safe(on_exit)
@@ -60,13 +73,6 @@ function M.start_debugger(config, on_launch, on_exit, on_error, on_stderror)
 	local stderr = uv.new_pipe(false)
 	local handle, pid_or_err
 
-	local entrypoint = debugger_entrypoint(config.debugger_path)
-
-	if not file_exists(entrypoint) then
-		on_error("Debugger entrypoint file '" .. entrypoint .. "' does not exist. Did it build properly?")
-		return
-	end
-
 	local exit = function(code, signal)
 		stdin:close()
 		stdout:close()
@@ -77,10 +83,14 @@ function M.start_debugger(config, on_launch, on_exit, on_error, on_stderror)
 		on_exit(code, signal)
 	end
 
-	handle, pid_or_err = uv.spawn(config.node_path, {
-		args = {
-			entrypoint,
-		},
+	local ok, cmd, args = pcall(get_spawn_cmd, config)
+	if not ok then
+		on_error(cmd)
+		return
+	end
+
+	handle, pid_or_err = uv.spawn(cmd, {
+		args = args,
 		stdio = { stdin, stdout, stderr },
 		detached = true,
 	}, function(code, signal)

--- a/lua/dap-vscode-js/utils.lua
+++ b/lua/dap-vscode-js/utils.lua
@@ -125,4 +125,5 @@ function M.start_debugger(config, on_launch, on_exit, on_error, on_stderror)
 	return proc
 end
 
+M.get_spawn_cmd = get_spawn_cmd
 return M

--- a/tests/unit/utils_spec.lua
+++ b/tests/unit/utils_spec.lua
@@ -1,7 +1,8 @@
 local utils = require("dap-vscode-js.utils")
 local async = require("plenary.async.tests")
 local wrap = require("plenary.async.async").wrap
--- local async = require"dap-vscode-js-tests.utils".async
+local config = require("dap-vscode-js.config")
+local test_utils = require("__dap_js_test_util")
 
 describe("dap-vscode-js.utils", function()
 	describe(".start_debugger", function()
@@ -22,5 +23,27 @@ describe("dap-vscode-js.utils", function()
 				end)
 			end, 1)
 		)
+	end)
+
+	describe(".get_spawn_cmd", function()
+		it("will use debug_cmd when provided", function()
+			test_utils.setup_dapjs({
+				debugger_cmd = { "a", "b", "c" },
+			})
+
+			local cmdname, args = utils.get_spawn_cmd(config)
+			assert.same(cmdname, "a")
+			assert.same(args, { "b", "c" })
+		end)
+
+		it("will error when debug_cmd is invalid", function()
+			test_utils.setup_dapjs({
+				debugger_cmd = {},
+			})
+
+			assert.errors(function()
+				utils.get_spawn_cmd(config)
+			end)
+		end)
 	end)
 end)


### PR DESCRIPTION
This is to allow providing a command in PATH that launches the debug server,
instead of having to deal with providing absolute paths.
