### PR TITLE
Adds support for the `node` adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,15 @@ Every platform supported by vscode is provided. This includes:
 
 | Adapter             | Platform          | Support     |
 |---------------------|-------------------|-------------|
-| `pwa-node`          | Node.js           | Full        |
+| `node`              | Node.js           | Full        |
+| *`pwa-node`         | Node.js           | Full        |
 | `pwa-chrome`        | Chrome            | Partial[^1] |
 | `pwa-msedge`        | Edge              | Untested    |
 | `node-terminal`     | Node.js           | Untested    |
 | `pwa-extensionHost` | VSCode Extensions | Untested    |
+
+> *As of July 2022, pwa-node is not in preview anymore and is the default node debugger (aka `node` adapter above). 
+> Please use the `node` debugger instead as `pwa-node` is scheduled for deprecation.
 
 ## Installation
 

--- a/lua/dap-vscode-js/dap.lua
+++ b/lua/dap-vscode-js/dap.lua
@@ -2,7 +2,7 @@ local M = {}
 local dap = require("dap")
 local js_adapter = require("dap-vscode-js.adapter")
 
-local DAP_TYPES = { "pwa-node", "pwa-chrome", "pwa-msedge", "node-terminal", "pwa-extensionHost" }
+local DAP_TYPES = { "node", "pwa-node", "pwa-chrome", "pwa-msedge", "node-terminal", "pwa-extensionHost" }
 
 local function filter_adapters(list)
 	return vim.tbl_filter(function(el)

--- a/tests/integration/node_spec.lua
+++ b/tests/integration/node_spec.lua
@@ -16,6 +16,94 @@ local launch_config = {
 
 local current_session
 
+describe("node", function()
+	before_each(function()
+		test_utils.reset()
+		test_utils.setup_dapjs()
+	end)
+
+	describe("typescript", function()
+		async.it(
+			"can be debugged with simple config",
+			wrap(function(done)
+				test_utils.open_test("test1.ts")
+
+				local console = {}
+
+				local output_happened = false
+				local termination_happened = false
+
+				local function try_exit()
+					if output_happened and termination_happened then
+						done()
+					end
+				end
+
+				test_utils.add_listener("before", "event_output", function(session, body)
+					if body.category == "stdout" then
+						table.insert(console, body.output)
+					end
+
+					if #console >= 3 then
+						assert.same(console, { "4\n", "2\n", "6\n" })
+
+						output_happened = true
+					end
+
+					try_exit()
+				end)
+
+				test_utils.on_session_end(function()
+					termination_happened = true
+
+					try_exit()
+				end)
+
+				dap.run(launch_config)
+			end, 1)
+		)
+
+		async.it(
+			"wont reject valid breakpoints",
+			wrap(function(done)
+				test_utils.open_test("test1.ts")
+				local bufexpr = vim.api.nvim_get_current_buf()
+
+				test_utils.set_breakpoint(3, bufexpr)
+
+				test_utils.add_listener("after", "event_stopped", function(session, body)
+					assert.equal(body.reason, "breakpoint")
+
+					local bps = breakpoints.get(bufexpr)[bufexpr]
+
+					assert.equal(#bps, 1)
+
+					local bp_signs = test_utils.get_breakpoint_signs(bufexpr)
+
+					assert.equal(#bp_signs, 1)
+
+					for _, bp in ipairs(bp_signs) do
+						assert.equal(#bp.signs, 1)
+
+						for _, sign in ipairs(bp.signs) do
+							assert.equal(sign.name, "DapBreakpoint")
+						end
+					end
+
+					done()
+				end)
+
+				test_utils.on_session_end(function()
+					done()
+				end)
+
+				dap.run(launch_config)
+			end, 1)
+		)
+	end)
+end)
+
+-- To be deprecated
 describe("pwa-node", function()
 	before_each(function()
 		test_utils.reset()


### PR DESCRIPTION
As of July 2022, the `pwa-node` adapter became the default node adapter and is now available under the `node` type by default. 

In this PR, I've updated the config filter to support the launch configuration containing the `node` type. I've left the existing `pwa-node` type for backwards compatibility until such time that the `pwa-node` adapter will become officially deprecated. 

Essentially, this is a name change - so I've copied the tests across to make sure that we can catch any funny business if the two adapter diverge.

I'm very new to lua, so have used your workflow to run test cases, and change requests are encouraged and welcome :)

