### PR TITLE
Update Packer installation doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ You must download and build a copy of [vscode-js-debug](https://github.com/micro
 use {
   "microsoft/vscode-js-debug",
   opt = true,
-  run = "npm install --legacy-peer-deps && npm run compile" 
+  run = "npm install --legacy-peer-deps && npm run compile" ,
+  tag = "v1.*"
 }
 ```
 


### PR DESCRIPTION
Add a tag instruction in Packer installation doc to freeze `vscode-js-debug` version to 1.x and fix #23 

Closes #23 