### PR TITLE
Register child session as child

### DIFF
--- a/lua/dap-vscode-js/adapter.lua
+++ b/lua/dap-vscode-js/adapter.lua
@@ -42,9 +42,11 @@ local function start_child_session(request, mode, parent, proc)
 				logger.log("DAP connection failed to start: " .. err, vim.log.levels.ERROR)
 			else
 				logger.debug("Initializing child session on port " .. tostring(child_port))
-
+				if parent.children then
+					session.parent = parent
+					parent.children[session.id] = session
+				end
 				session:initialize(body.config)
-
 				js_session.register_session(session, parent, proc)
 			end
 		end


### PR DESCRIPTION
Similar to the nvim-dap startDebugging support, this sets
children/parent on the session

See https://github.com/mfussenegger/nvim-dap/blob/72684a4d70f0ecd45efe5ea76e9510e0b2e4d600/lua/dap/session.lua#L1022-L1023

This will cause the session hierarchy to be visible when using something
like `:lua local w = require('dap.ui.widgets');
w.sidebar(w.sessions).open();` and should ensure the child session
receives all breakpoint changes
