### PR TITLE
Compare log level to `log_console_level`

### DIFF
--- a/lua/dap-vscode-js/log.lua
+++ b/lua/dap-vscode-js/log.lua
@@ -15,7 +15,7 @@ M.log = function(msg, level, reflect_depth)
 
 	msg = M.msg_prefix .. msg
 	
-	if config.log_file_level and level >= config.log_file_level and config.log_file_path then
+	if config.log_file_level and level >= config.log_console_level and config.log_file_path then
 		local fp, err = io.open(config.log_file_path, "a")
 		if not fp then
 			print(err)


### PR DESCRIPTION
Instead of comparing log `level` to `log_file_level`, compare it to `log_console_level`. `log_file_level` is a boolean indicating whether we should log or not while `log_console_level` is a log level number.