### PR TITLE
docs(readme): use npm ci when building vscode-js-debug

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ You must download and build a copy of [vscode-js-debug](https://github.com/micro
 use {
   "microsoft/vscode-js-debug",
   opt = true,
-  run = "npm install --legacy-peer-deps && npx gulp vsDebugServerBundle && mv dist out" 
+  run = "npm ci --loglevel=error && npx gulp vsDebugServerBundle && mv dist out" 
 }
 ```
 
@@ -43,7 +43,7 @@ use {
 ```bash
 git clone https://github.com/microsoft/vscode-js-debug
 cd vscode-js-debug
-npm install --legacy-peer-deps
+npm ci
 npx gulp vsDebugServerBundle
 mv dist out
 ```


### PR DESCRIPTION
Using `npm install` modifies the `package-lock.json` file which makes plugin managers like Lazy & Packer fail on subsequent updates. Since the vscode-js-debug repo already ships with a `package-lock.json`, we can use `npm ci` to speed up the install and potentially avoid breakages.